### PR TITLE
Minor updates for sget's existence outside of cosign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binaries for programs and plugins
+.DS_STORE
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# IDEs
+.vscode
+.idea
+
+# fuzzing artifacts
+*.libfuzzer
+*fuzz.a
+
+bin*
+dist/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,7 @@
 @sigstore/sget-codeowners
+
+# The CODEOWNERS are managed via a GitHub team, but the current list is (in alphabetical order):
+
+# dlorenc
+# imjasonh
+# luhring

--- a/main.go
+++ b/main.go
@@ -16,33 +16,12 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
-	"strings"
 
 	"github.com/sigstore/sget/cli"
 )
 
 func main() {
-	// Fix up flags to POSIX standard flags.
-	for i, arg := range os.Args {
-		if (strings.HasPrefix(arg, "-") && len(arg) == 2) || (strings.HasPrefix(arg, "--") && len(arg) >= 4) {
-			continue
-		}
-		if strings.HasPrefix(arg, "--") && len(arg) == 3 {
-			// Handle --o, convert to -o
-			newArg := fmt.Sprintf("-%c", arg[2])
-			fmt.Fprintf(os.Stderr, "WARNING: the flag %s is deprecated and will be removed in a future release. Please use the flag %s.\n", arg, newArg)
-			os.Args[i] = newArg
-		} else if strings.HasPrefix(arg, "-") {
-			// Handle -output, convert to --output
-			newArg := fmt.Sprintf("-%s", arg)
-			fmt.Fprintf(os.Stderr, "WARNING: the flag %s is deprecated and will be removed in a future release. Please use the flag %s.\n", arg, newArg)
-			os.Args[i] = newArg
-		}
-	}
-
 	if err := cli.New().Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)
 	}


### PR DESCRIPTION
1. Removes handling of the non-POSIX-compliant args (e.g. `-key`) that Cosign deprecated a while back, since this `sget` project is starting anew
2. Adds a `.gitignore` similar to Cosign's (I use GoLand and noticed `.idea/` kept creeping into `git status`)
3. Adds an initial `CODEOWNERS` list, similar to other sigstore repos