### PR TITLE
Handle empty cert from Rekor; plumb through ctx

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -18,8 +19,12 @@ func (f tempFile) out() io.ReadCloser {
 	return f.f
 }
 
-func fetch(url string, discard bool) (*tempFile, error) {
-	resp, err := http.Get(url)
+func fetch(ctx context.Context, url string, discard bool) (*tempFile, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"log"
 	neturl "net/url"
 	"os"
+	"os/signal"
 	"strings"
 
 	fapi "github.com/sigstore/fulcio/pkg/api"
@@ -28,6 +30,8 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
 			url := args[0]
 			u, err := neturl.Parse(url)
 			if err != nil {
@@ -39,7 +43,7 @@ func main() {
 			}
 
 			// Validate digest if specified.
-			tmp, err := fetch(url, false)
+			tmp, err := fetch(ctx, url, false)
 			if err != nil {
 				return fmt.Errorf("error getting digest for %q: %w", url, err)
 			}
@@ -101,7 +105,10 @@ func main() {
 
 				// TODO: Check that the URL matches, not just the digest.
 
-				block, _ := pem.Decode([]byte(ent.Spec.PublicKey))
+				if len(ent.Spec.PublicKey) == 0 {
+					continue
+				}
+				block, _ := pem.Decode(ent.Spec.PublicKey)
 				if block == nil {
 					return fmt.Errorf("parsing certificate PEM; block is nil")
 				}
@@ -178,7 +185,9 @@ func main() {
 	addSign(root)
 	addTrust(root)
 
-	if err := root.Execute(); err != nil {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+	if err := root.ExecuteContext(ctx); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/sign.go
+++ b/sign.go
@@ -38,6 +38,8 @@ func addSign(cmd *cobra.Command) {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
 			url := args[0]
 			u, err := neturl.Parse(url)
 			if err != nil {
@@ -48,7 +50,7 @@ func addSign(cmd *cobra.Command) {
 			}
 
 			// Validate digest if specified.
-			tmp, err := fetch(url, true)
+			tmp, err := fetch(ctx, url, true)
 			if err != nil {
 				return fmt.Errorf("error getting digest for %q: %w", url, err)
 			}


### PR DESCRIPTION
I found some cases where the cert coming back from Rekor was empty, and this caused sget to fail miserably. Instead, just ignore these and keep looking for matching identities.

This also plumbs through a cancellable context, currently only through `fetch`ing the URL, so users can ctrl+C to cancel execution. Rekor and Fulcio calls are not plumbed yet.

```release-note
Ctrl+C cancels URL fetching, better handle empty certs from Rekor
```
